### PR TITLE
Fix CC timing in limit cut

### DIFF
--- a/Mechanics/LimitCutDemo.json
+++ b/Mechanics/LimitCutDemo.json
@@ -340,7 +340,7 @@
           },
           {
             "$type": "WaitEvent",
-            "timeToWait": 6.0
+            "timeToWait": 7.5
           },
           {
             "$type": "SetEnemyMovement",


### PR DESCRIPTION
Currently, CC appears at the same time as the 3rd hawk blaster goes off. In reality there is a 1.5 second delay after the explosion before limit cut begins resolving.

Accompanying update to LINQ-script: https://github.com/xiv-stats/xiv-sim-documentation/pull/15